### PR TITLE
Add published site URL to the publish workflow summary.

### DIFF
--- a/.github/workflows/__call__publish.yaml
+++ b/.github/workflows/__call__publish.yaml
@@ -32,4 +32,13 @@ jobs:
           path: ./website/
 
       - name: 'Deploy to GitHub Pages'
+        id: deployment
         uses: actions/deploy-pages@v5
+
+      - name: 'Write published URL to summary'
+        run: |
+          {
+            echo '## Published site'
+            echo ''
+            echo "- URL: [${{ steps.deployment.outputs.page_url }}](${{ steps.deployment.outputs.page_url }})"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Give deploy-pages a stable step id and write the page URL into the run summary after deployment.